### PR TITLE
Adding c++0x flag to configure.ac

### DIFF
--- a/QuantLib/configure.ac
+++ b/QuantLib/configure.ac
@@ -55,6 +55,7 @@ fi
 # Continue setup
 
 AC_PROG_CC
+CXXFLAGS="$CXXFLAGS -std=c++0x"
 AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_LIBTOOL


### PR DESCRIPTION
Without that I could not compile on Ubuntu (got error message from clang. Used info from here to fix: http://stackoverflow.com/questions/7987952/how-to-use-c11-features-with-autoconf).
